### PR TITLE
 Use OPENFDA_API_KEY environment variable if available

### DIFF
--- a/R/openfda.R
+++ b/R/openfda.R
@@ -84,7 +84,7 @@ fda_query <- function(base) {
   q$base = base
   q$limit = FALSE
   q$skip = FALSE
-  q$key = FALSE
+  q$key = Sys.getenv("OPENFDA_API_KEY", NA)
   q$count = FALSE
   q$debug = TRUE
   q$filters = vector("character")
@@ -159,7 +159,7 @@ fda_skip <- function(q, skip) {
 #'
 #' @return fda_query
 #' @export
-fda_api_key <- function(q, key) {
+fda_api_key <- function(q, key = Sys.getenv("OPENFDA_API_KEY", NA)) {
   q = copy_query(q)
   q$key = key
   q
@@ -175,7 +175,7 @@ fda_url <- function(q) {
 
   args = c(search);
 
-  if (q$key != FALSE) {
+  if (!is.na(q$key)) {
     args = c(args, paste("api_key", q$key, sep="="))
   }
 

--- a/openfda.Rproj
+++ b/openfda.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
This way you don't have to use `fda_api_key()` at all if `OPENFDA_API_KEY` is set